### PR TITLE
Force LF line endings for bin script.

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,10 @@
+# EditorConfig helps developers define and maintain consistent
+# coding styles between different editors and IDEs
+# editorconfig.org
+root = true
+
+[got-swag]
+# bin scripts (node scripts with shebang) must not have DOS formatted line
+# endings. Use LF instead, see https://github.com/npm/npm/issues/4607
+end_of_line = lf
+charset = utf-8

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,3 @@
+# Force LF for the bin script
+# See https://github.com/npm/npm/issues/4607
+got-swag eol=lf

--- a/bin/got-swag
+++ b/bin/got-swag
@@ -3,7 +3,7 @@
 var gotSwag = require( '../' );
 
 gotSwag.dispatch( process.argv.slice( 2 ) ).catch( function ( err ) {
-  // exit code 2 on error
+  // Exit code 2 on error
   console.error( err.message );
   process.exit( 2 );
 } );


### PR DESCRIPTION
`npm install got-swag --global` pulls down `got-swag` as a DOS formatted file. These Windows-style line endings trigger `env: ‘node\r’: No such file or directory` when Node tries to run the file in a Linux/POSIX shell, see https://github.com/npm/npm/issues/4607

I added an EditorConfig and .gitattributes to enforce LF line endings in the repo's working directory, no matter the platform.

The trivial change to `got-swag` forces an update when you pull. 

