### PR TITLE
Feature: expose Buffer.byteLength in sandbox as utility function

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,6 +102,9 @@ For example, see [petstore.yaml](examples/petstore.yaml) (embedded) and
 
 - `encodeURIComponent( s )` encodes a string for URI transmission
 - `log( value )` logs a value
+- `stringify( value )` alias of JSON.stringify
+- `parse( string )` alias of JSON.parse
+- `byteLength( string )` alias of Buffer.byteLength for computing 'Content-Length' header manually 
 - `monkeyAuth()` tries to authenticate using known method/credentials
 - `monkeyGet()` tries to GET using known parameters
 

--- a/lib/createSandbox.js
+++ b/lib/createSandbox.js
@@ -45,6 +45,7 @@ function createSandbox( api, options ) {
 
     parse: JSON.parse,
     stringify: JSON.stringify,
+    byteLength: Buffer.byteLength,    
 
     // request functions
     request: function ( options ) {


### PR DESCRIPTION
Addresses use case on which the user may need to compute the
'Content-Length' header manually

Implements #20 